### PR TITLE
'Updated AL-Go System Files'

### DIFF
--- a/.github/AL-Go-Settings.json
+++ b/.github/AL-Go-Settings.json
@@ -1,4 +1,4 @@
-{
+﻿{
     "type":  "PTE",
     "templateUrl":  "https://github.com/ctmcomputer/AL-Go-PTE@main"
 }

--- a/.github/RELEASENOTES.copy.md
+++ b/.github/RELEASENOTES.copy.md
@@ -1,11 +1,26 @@
-## preview
+﻿## preview
+
+Note that when using the preview version of AL-Go for GitHub, you need to Update your AL-Go system files, as soon as possible when told to do so.
 
 ### Issues
 - Issue #143 Commit Message for **Increment Version Number** workflow
+- Issue #160 Create local DevEnv aith appDependencyProbingPaths
+- Issue #156 Versioningstrategy 2 doesn't use 24h format
+- Issue #155 Initial Add existing app fails with "Cannot find path"
+- Issue #152 Error when loading dependencies from releases
+- Issue #168 Regression in preview fixed
+
+### Settings
+- New Repo setting: CICDPushBranches can be specified as an array of branches, which triggers a CI/CD workflow on commit. Default is main', release/\*, feature/\*
+- New Repo setting: CICDPullRequestBranches can be specified as an array of branches, which triggers a CI/CD workflow on pull request. Default is main
+- New Repo setting: CICDSchedule can specify a CRONTab on when you want to run CI/CD on a schedule. Note that this will disable Push and Pull Request triggers unless specified specifically using CICDPushBranches or CICDPullRequestBranches
+- New Repo setting: UpdateGitHubGoSystemFilesSchedule can specify a CRONTab on when you want to Update AL-Go System Files. Note that when running on a schedule, update AL-Go system files will perfom a direct commit and not create a pull request.
 
 ### All workflows
 - Support 2 folder levels projects (apps\w1, apps\dk etc.)
 - Better error messages for if an error occurs within an action
+- Special characters are now supported in secrets
+- Initial support for agents running inside containers on a host
 
 ### Update AL-Go System Files Workflow
 - workflow now displays the currently used template URL when selecting the Run Workflow action
@@ -17,7 +32,7 @@
 - Use mutex around ReadSecrets to ensure that multiple agents on the same host doesn't clash
 
 ### CI/CD and Publish To New Environment
-- base functionality for selecting a specific GitHub runner for an environment
+- Base functionality for selecting a specific GitHub runner for an environment
 
 ### localDevEnv.ps1 and cloudDevEnv.ps1
 - Display clear error message if something goes wrong

--- a/.github/workflows/CICD.yaml
+++ b/.github/workflows/CICD.yaml
@@ -1,4 +1,4 @@
-name: CI/CD
+﻿name: CI/CD
 
 on:
   workflow_dispatch:
@@ -6,11 +6,12 @@ on:
     paths-ignore:
       - 'README.md'
       - '.github/**'
-    branches: [ main, release/*, feature/* ]
+    branches: [ 'main', 'release/*', 'feature/*' ]
   pull_request:
     paths-ignore:
       - 'README.md'
       - '.github/**'
+    branches: [ 'main' ]
 
 permissions:
   contents: read
@@ -138,7 +139,7 @@ jobs:
         if: github.event_name != 'pull_request' && (github.ref_name == 'main' || startswith(github.ref_name, 'release/'))
         with:
           name: ${{ env.appsArtifactsName }}
-          path: '${{ matrix.project }}/output/Apps/'
+          path: '${{ matrix.project }}/.buildartifacts/Apps/'
           if-no-files-found: ignore
 
       - name: Publish artifacts - dependencies
@@ -146,7 +147,7 @@ jobs:
         if: github.event_name != 'pull_request' && (github.ref_name == 'main' || startswith(github.ref_name, 'release/'))
         with:
           name: ${{ env.dependenciesArtifactsName }}
-          path: '${{ matrix.project }}/output/Dependencies/'
+          path: '${{ matrix.project }}/.buildartifacts/Dependencies/'
           if-no-files-found: ignore
 
       - name: Publish artifacts - test apps
@@ -154,7 +155,7 @@ jobs:
         if: github.event_name != 'pull_request' && (github.ref_name == 'main' || startswith(github.ref_name, 'release/'))
         with:
           name: ${{ env.testAppsArtifactsName }}
-          path: '${{ matrix.project }}/output/TestApps/'
+          path: '${{ matrix.project }}/.buildartifacts/TestApps/'
           if-no-files-found: ignore
 
       - name: Publish artifacts - build output

--- a/.github/workflows/UpdateGitHubGoSystemFiles.yaml
+++ b/.github/workflows/UpdateGitHubGoSystemFiles.yaml
@@ -1,4 +1,4 @@
-name: Update AL-Go System Files
+﻿name: Update AL-Go System Files
 
 on:
   workflow_dispatch:
@@ -65,6 +65,16 @@ jobs:
             Add-Content -Path $env:GITHUB_ENV -Value "TemplateUrl=$templateUrl"
           }
 
+      - name: Calculate DirectCommit
+        run: |
+          $directCommit = '${{ github.event.inputs.directCommit }}'
+          Write-Host '${{ github.event_name }}'
+          if ('${{ github.event_name }}' -eq 'schedule') {
+            Write-Host "Running Update AL-Go System Files on a schedule. Setting DirectCommit = Y"
+            $directCommit = 'Y'
+          }
+          Add-Content -Path $env:GITHUB_ENV -Value "DirectCommit=$directCommit"
+
       - name: Update AL-Go system files
         uses: ctmcomputer/AL-Go-Actions/CheckForUpdates@main
         with:
@@ -72,7 +82,7 @@ jobs:
           token: ${{ env.ghTokenWorkflow }}
           Update: Y
           templateUrl: ${{ env.TemplateUrl }}
-          directCommit: ${{ github.event.inputs.directCommit }}
+          directCommit: ${{ env.directCommit }}
 
   PostProcess:
     if: always()


### PR DESCRIPTION
## preview

Note that when using the preview version of AL-Go for GitHub, you need to Update your AL-Go system files, as soon as possible when told to do so.

### Issues
- Issue #143 Commit Message for **Increment Version Number** workflow
- Issue #160 Create local DevEnv aith appDependencyProbingPaths
- Issue #156 Versioningstrategy 2 doesn't use 24h format
- Issue #155 Initial Add existing app fails with "Cannot find path"
- Issue #152 Error when loading dependencies from releases
- Issue #168 Regression in preview fixed

### Settings
- New Repo setting: CICDPushBranches can be specified as an array of branches, which triggers a CI/CD workflow on commit. Default is main', release/\*, feature/\*
- New Repo setting: CICDPullRequestBranches can be specified as an array of branches, which triggers a CI/CD workflow on pull request. Default is main
- New Repo setting: CICDSchedule can specify a CRONTab on when you want to run CI/CD on a schedule. Note that this will disable Push and Pull Request triggers unless specified specifically using CICDPushBranches or CICDPullRequestBranches
- New Repo setting: UpdateGitHubGoSystemFilesSchedule can specify a CRONTab on when you want to Update AL-Go System Files. Note that when running on a schedule, update AL-Go system files will perfom a direct commit and not create a pull request.

### All workflows
- Support 2 folder levels projects (apps\w1, apps\dk etc.)
- Better error messages for if an error occurs within an action
- Special characters are now supported in secrets
- Initial support for agents running inside containers on a host

### Update AL-Go System Files Workflow
- workflow now displays the currently used template URL when selecting the Run Workflow action

### CI/CD workflow
- Better detection of changed projects
- appDependencyProbingPaths did not support multiple projects in the same repository for latestBuild dependencies
- appDependencyProbingPaths with release=latestBuild only considered the last 30 artifacts
- Use mutex around ReadSecrets to ensure that multiple agents on the same host doesn't clash

### CI/CD and Publish To New Environment
- Base functionality for selecting a specific GitHub runner for an environment

### localDevEnv.ps1 and cloudDevEnv.ps1
- Display clear error message if something goes wrong
